### PR TITLE
Fix terminal sizing and scrolling

### DIFF
--- a/config.h
+++ b/config.h
@@ -134,6 +134,9 @@ unsigned int defaultrcs = 258;
  */
 unsigned int cursorshape = 2;
 
+unsigned int cols = 80;
+unsigned int rows = 24;
+
 /*
  * Default colour and shape of the mouse cursor
  */

--- a/st.c
+++ b/st.c
@@ -58,8 +58,6 @@ char *argv0;
 #define ISCONTROLC1(c)		(BETWEEN(c, 0x80, 0x9f))
 #define ISCONTROL(c)		(ISCONTROLC0(c) || ISCONTROLC1(c))
 #define ISDELIM(u)		(utf8strchr(worddelimiters, u) != NULL)
-#define TLINE(y)		((y) < term.scr ? term.hist[((y) + term.histi - term.scr \
-				+ histsize + 1) % histsize] : term.line[(y) - term.scr])
 
 /* constants */
 #define ISO14755CMD		"dmenu -p codepoint: </dev/null"

--- a/st.h
+++ b/st.h
@@ -21,6 +21,9 @@
 #define TRUECOLOR(r,g,b)	(1 << 24 | (r) << 16 | (g) << 8 | (b))
 #define IS_TRUECOL(x)		(1 << 24 & (x))
 
+#define TLINE(y)    ((y) < term.scr ? term.hist[((y) + term.histi - term.scr \
+                    + histsize + 1) % histsize] : term.line[(y) - term.scr])
+
 enum glyph_attribute {
 	ATTR_NULL       = 0,
 	ATTR_BOLD       = 1 << 0,

--- a/x.c
+++ b/x.c
@@ -1506,11 +1506,11 @@ drawregion(int x1, int y1, int x2, int y2)
 		term.dirty[y] = 0;
 
 		specs = term.specbuf;
-		numspecs = xmakeglyphfontspecs(specs, &term.line[y][x1], x2 - x1, x1, y);
+		numspecs = xmakeglyphfontspecs(specs, &TLINE(y)[x1], x2 - x1, x1, y);
 
 		i = ox = 0;
 		for (x = x1; x < x2 && i < numspecs; x++) {
-			new = term.line[y][x];
+			new = TLINE(y)[x];
 			if (new.mode == ATTR_WDUMMY)
 				continue;
 			if (ena_sel && selected(x, y))
@@ -1804,8 +1804,6 @@ run(void)
 int
 main(int argc, char *argv[])
 {
-    int cols, rows;
-
 	xw.l = xw.t = 0;
 	xw.isfixed = False;
 	win.cursor = cursorshape;


### PR DESCRIPTION
Mainly the changes in `x.c` fixed the issues, the added lines to `config.h` are needed because of the removed `int cols, rows;` line.